### PR TITLE
s-11-tr-pedido_medicamento_unidades y s-12-tr-pedido_medicamento_unidades_prueba.

### DIFF
--- a/s-00-main.sql
+++ b/s-00-main.sql
@@ -7,4 +7,6 @@
 @s-07-sinonimos.sql
 @s-08-vistas.sql
 @s-09-carga-inicial.sql
-@s-10-consultas.sql
+--@s-10-consultas.sql
+@s-11-tr-pedido_medicamento_unidades.sql
+@s-12-tr-pedido_medicamento_unidades_prueba.sql

--- a/s-01-usuarios.sql
+++ b/s-01-usuarios.sql
@@ -27,7 +27,7 @@ create user vl_proy_invitado identified by proyecto;
 
 prompt Creando roles
 create role rol_admin;
-grant create session, create table, create view, create procedure, create sequence, create public synonym to rol_admin;
+grant create session, create table, create view, create procedure, create sequence, create public synonym, create trigger to rol_admin;
 create role rol_invitado;
 grant create session, create synonym to rol_invitado;
 

--- a/s-11-tr-pedido_medicamento_unidades.sql
+++ b/s-11-tr-pedido_medicamento_unidades.sql
@@ -1,0 +1,39 @@
+--@Autor(es): Vigi Garduño Marco Alejandro, López Campillo Francisco Daniel
+--@Fecha creación: 08/06/2024
+--@Descripción: Trigger que se dispara cuando se solicita un medicamento en un pedido.
+
+--Comentarios de la fecha, autores y descripcion
+Prompt conectado como admin
+connect vl_proy_admin/proyecto
+Prompt Creando trigger pedido_medicamento_trigger
+create or replace trigger pedido_medicamento_trigger
+  before insert or update or delete of unidades on pedido_medicamento
+  for each row
+  declare
+    v_unidades_disponibles inventario_medicamento.unidades%type;
+  begin
+    case
+      when inserting then
+        select unidades into v_unidades_disponibles
+        from inventario_medicamento
+        where farmacia_id = :new.farmacia_id
+          and presentacion_medicamento_id= :new.presentacion_medicamento_id;
+        if :new.unidades > v_unidades_disponibles then
+          dbms_output.put_line('No hay unidades suficientes del medicamento con presentacion_medicamento_id = '
+            || :new.presentacion_medicamento_id
+            || ' en la farmacia con centro_operaciones_id = '
+            || :new.farmacia_id
+            || '.'
+          );
+          raise_application_error(-20001, 'No hay suficiente stock del medicamento en la farmacia solicitada.');
+        end if;
+      when updating then
+        dbms_output.put_line('No se puede actualizar las unidades solicitadas en un pedido');
+        raise_application_error(-20002,'No se permiten actualizaciones en las unidades solicitadas de un medicamento.');
+      when deleting then
+        dbms_output.put_line('No se puede eliminar las unidades solicitadas en un pedido');
+        raise_application_error(-20003,'No se permiten eliminaciones en las unidades solicitadas de un medicamento.');
+    end case;
+  end;
+/
+show errors

--- a/s-12-tr-pedido_medicamento_unidades_prueba.sql
+++ b/s-12-tr-pedido_medicamento_unidades_prueba.sql
@@ -1,0 +1,139 @@
+--@Autor(es):       Francisco Daniel López
+--@Fecha creación:  08/06/2024
+--@Descripción:     Prueba idempotente de s-11-tr-pedido_medicamento_unidades.sql
+Prompt conectado como admin
+connect vl_proy_admin/proyecto
+Prompt Probando trigger pedido_medicamento_trigger
+set serveroutput on
+prompt Ejecutando pruebas automáticas
+
+Prompt =======================================
+Prompt Prueba 1 (negativa: La prueba es exitosa si el trigger lanza un Error)
+prompt Intentando registrar un pedido que solicita más unidades de las que hay en el inventario de la farmacia
+Prompt ========================================
+begin
+  insert into pedido_medicamento(pedido_medicamento_id,unidades,pedido_id,farmacia_id,presentacion_medicamento_id)
+  values (pedido_medicamento_seq.nextval,31,4,1,7);
+  raise_application_error(-20010,'ERROR: El trigger no generó error -20001');
+exception
+  when others then
+    if sqlcode = -20001 then
+      dbms_output.put_line('Ok - Prueba exitosa!, se esperaba error -20001');
+    else
+      dbms_output.put_line(' ERROR - código no esperado: '|| sqlcode);
+      raise; ---importante. El error se relanza para ver la causa real
+    end if;
+end;
+/
+
+
+Prompt OK, prueba 1 exitosa.
+
+
+Prompt =======================================
+Prompt Prueba 2 (positiva: La prueba es exitosa si se ejecuta correctamente la sentencia)
+prompt Intentando registar un pedido que solicita menos unidades de las que hay en el inventario de la farmacia
+Prompt ========================================
+begin
+  insert into pedido_medicamento(pedido_medicamento_id,unidades,pedido_id,farmacia_id,presentacion_medicamento_id)
+  values (pedido_medicamento_seq.nextval,30,4,1,7);
+  dbms_output.put_line('Ok - Prueba exitosa!, el registro váĺido se insertó correctamente.');
+exception
+  when others then
+    if sqlcode = -20001 then
+      dbms_output.put_line('Ok - Prueba fallida. NO SE ESPERABA ERROR -20001');
+    else
+      dbms_output.put_line('ERROR: El trigger generó un error inesperado.');
+      raise; ---importante. El error se relanza para ver la causa real
+    end if;
+end;
+/
+
+Prompt OK, prueba 2 exitosa.
+
+
+Prompt =======================================
+Prompt Prueba 3 (negativa: La prueba es exitosa si el trigger lanza un Error)
+prompt Intentando registrar un pedido que solicita un medicamento que no existe en la farmacia.
+Prompt ========================================
+begin
+  insert into pedido_medicamento(pedido_medicamento_id,unidades,pedido_id,farmacia_id,presentacion_medicamento_id)
+  values (pedido_medicamento_seq.nextval,30,4,1,40);
+exception
+  when others then
+    if sqlcode = -20001 then
+      raise_application_error(-20011,'ERROR: El trigger generó error -20001');
+    elsif sqlcode = 100 then
+      dbms_output.put_line('Ok - Prueba exitosa! - el error 100 implica que el medicamento no existe en la farmacia solicitiada.');
+    else
+      dbms_output.put_line(' ERROR - código no esperado: '|| sqlcode);
+      raise; ---importante. El error se relanza para ver la causa real
+    end if;
+end;
+/
+
+Prompt OK, prueba 3 exitosa.
+
+
+Prompt =======================================
+Prompt Prueba 4 (negativa: La prueba es exitosa si el trigger lanza un Error)
+prompt Intentando actualizar las unidades de un medicamento en un pedido.
+Prompt ========================================
+begin
+  update pedido_medicamento
+  set unidades = 10
+  where pedido_medicamento_id = 4
+  and pedido_id = 4
+  and farmacia_id = 6
+  and presentacion_medicamento_id=17;
+  raise_application_error(-20012,'ERROR: El trigger no generó error -20002');
+exception
+  when others then
+    if sqlcode = -20002 then
+      dbms_output.put_line('Ok - Prueba exitosa!, se esperaba error -20002');
+    else
+      dbms_output.put_line(' ERROR - código no esperado: '|| sqlcode);
+      raise; ---importante. El error se relanza para ver la causa real
+    end if;
+end;
+/
+
+Prompt OK, prueba 4 exitosa.
+
+
+Prompt =======================================
+Prompt Prueba 5 (negativa: La prueba es exitosa si el trigger lanza un Error)
+prompt Intentando eliminar las unidades de un medicamento en un pedido.
+Prompt ========================================
+declare
+	v_codigo number;
+	v_mensaje varchar2(1000);
+begin 
+	delete from pedido_medicamento
+	where pedido_medicamento_id = 4
+  and pedido_id = 4
+  and farmacia_id = 6
+  and presentacion_medicamento_id=17;
+
+  raise_application_error(-20004,
+    'ERROR: El trigger permite operaciones delete');
+
+exception
+	when others then
+    v_codigo := sqlcode;
+    v_mensaje := sqlerrm;
+    dbms_output.put_line('Codigo:  ' || v_codigo);
+    dbms_output.put_line('Mensaje: ' || v_mensaje);
+    if v_codigo = -20003 then
+    	dbms_output.put_line('Ok - Prueba exitosa!, se esperaba error -20003');
+    else
+    	dbms_output.put_line('ERROR, se obtuvo excepción no esperada');
+    	raise;
+    end if;
+end;
+/
+
+Prompt OK, prueba 5 exitosa.
+
+prompt Haciendo rollback para limpiar los datos de Prueba
+rollback;


### PR DESCRIPTION
Se otorga permisos para crear triggers en s-01-usuarios, se incluye la ejecución de los scripts en s-00-main.sql. El trigger creado y probado consiste en no permitir que se registre un pedido que en su solicitud de unidades rebase las existencias de un medicamento particular en una farmacia particular, e impide que se lleve a cabo en caso de que dicho medicamento no exista en la farmacia. También restringe las actualizaciones y eliminaciones de ese mismo campo.